### PR TITLE
Add .net6/7/8/9 support, remove netstandard2.0

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "9.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/src/itextsharp.csproj
+++ b/src/itextsharp.csproj
@@ -5,7 +5,7 @@
     <DefaultClientScript>JScript</DefaultClientScript>
     <DefaultHTMLPageLayout>Grid</DefaultHTMLPageLayout>
     <DefaultTargetSchema>IE50</DefaultTargetSchema>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0;</TargetFrameworks>
     <AssemblyTitle>iTextSharp</AssemblyTitle>
     <Description>iTextSharp 4.1.6 with added support for tables and images</Description>
     <Copyright>Copyright (C) 1999-2009 by Bruno Lowagie and Paulo Soares. All Rights Reserved.</Copyright>

--- a/tests/itextsharp.Tests/itextsharp.Tests.csproj
+++ b/tests/itextsharp.Tests/itextsharp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>


### PR DESCRIPTION
Some boyscouting while upgrading various nuget packages to new TFMs.

This currently doesn't have any automated builds or publishing so I'll circle back to that, but it's lower priority.